### PR TITLE
Change sample parts CTA for brwne demo

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -153,7 +153,7 @@ export default function Home() {
                 <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20">
                   <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
-                Use sample parts
+                Start with sample CAD
               </button>
               {!isLoggedIn && (
                 <p className="text-gray-600 mt-4">


### PR DESCRIPTION
## Summary
- Renames the logged-in sample parts CTA from `Use sample parts` to `Start with sample CAD`.
- This intentionally breaks brwne's current generated Playwright selector so the demo can show PR-branch failure and developer-approved healing.

## Demo Notes
- Main branch should pass before this PR is served locally.
- PR branch should fail the existing `tests/factorem-cnc-quote.spec.ts` selector until the healed locator is approved.